### PR TITLE
operatingsystemmajrelease fact is a string

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,17 +23,17 @@ class udev::params {
         }
       } else {
         case $::operatingsystemmajrelease {
-          5: {
+          '5': {
             $udev_package    = 'udev'
             $udevtrigger     = 'udevtrigger'
             $udevlogpriority = 'udevcontrol log_priority'
           }
-          6: {
+          '6': {
             $udev_package    = 'udev'
             $udevtrigger     = 'udevadm trigger'
             $udevlogpriority = 'udevadm control --log-priority'
           }
-          7: {
+          '7': {
             $udev_package    = 'systemd'
             $udevtrigger     = 'udevadm trigger'
             $udevlogpriority = 'udevadm control --log-priority'

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -5,7 +5,7 @@ describe 'udev::params', :type => :class do
     let :facts do
       {
         :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => 6,
+        :operatingsystemmajrelease => '6',
       }
     end
 
@@ -17,7 +17,7 @@ describe 'udev::params', :type => :class do
     let :facts do
       {
         :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => 4,
+        :operatingsystemmajrelease => '4',
       }
     end
 

--- a/spec/classes/udev_spec.rb
+++ b/spec/classes/udev_spec.rb
@@ -27,7 +27,7 @@ describe 'udev', :type => :class do
     let :facts do
       {
         :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => 6,
+        :operatingsystemmajrelease => '6',
       }
     end
 

--- a/spec/classes/udevadm/logpriority_spec.rb
+++ b/spec/classes/udevadm/logpriority_spec.rb
@@ -31,7 +31,7 @@ describe 'udev::udevadm::logpriority', :type => :class do
   describe 'for osfamily RedHat and operatingsystemmajrelease 6' do
     let(:facts) do
         { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :operatingsystemmajrelease => '6',
         }
     end
 
@@ -66,7 +66,7 @@ describe 'udev::udevadm::logpriority', :type => :class do
   describe 'for osfamily RedHat and operatingsystemmajrelease 5' do
     let(:facts) do
         { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => 5,
+          :operatingsystemmajrelease => '5',
         }
     end
 

--- a/spec/classes/udevadm/trigger_spec.rb
+++ b/spec/classes/udevadm/trigger_spec.rb
@@ -5,7 +5,7 @@ describe 'udev::udevadm::trigger', :type => :class do
   describe 'for osfamily RedHat' do
     let(:facts) do
         { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :operatingsystemmajrelease => '6',
         }
     end
 
@@ -21,7 +21,7 @@ describe 'udev::udevadm::trigger', :type => :class do
   describe 'for osfamily RedHat' do
     let(:facts) do
         { :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => 5,
+          :operatingsystemmajrelease => '5',
         }
     end
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -26,7 +26,7 @@ describe 'udev::rule', :type => :define do
     let :facts do
       {
         :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => 6,
+        :operatingsystemmajrelease => '6',
       }
     end
 


### PR DESCRIPTION
Fix params.pp for 4x parser.  The puppet 4x parser is type sensitive,
strings are not magically converted to ints and vice-versa.  The
operatingsystemmajrelease fact is returned by facter as a string:
https://tickets.puppetlabs.com/browse/FACT-962