### PR TITLE
Fix params.pp where Fedora release version is checked

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class udev::params {
     }
     'redhat': {
       if $::operatingsystem == 'Fedora' {
-        if (versioncmp($::operatingsystemmajrelease,20) >=0) {
+        if (versioncmp($::operatingsystemmajrelease,'20') >=0) {
           $udev_package    = 'systemd'
           $udevtrigger     = 'udevadm trigger'
           $udevlogpriority = 'udevadm control --log-priority'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class udev::params {
     }
     'redhat': {
       if $::operatingsystem == 'Fedora' {
-        if ($::operatingsystemmajrelease >= 20) {
+        if (versioncmp($::operatingsystemmajrelease,20) >=0) {
           $udev_package    = 'systemd'
           $udevtrigger     = 'udevadm trigger'
           $udevlogpriority = 'udevadm control --log-priority'


### PR DESCRIPTION
use versioncmp to compare fedora release (in puppet v4 $::operatingsystemmajrelease is treated strictly as a string)