### PR TITLE
Use udev::params for default parameter values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,8 +20,8 @@
 # include udev
 #
 class udev(
-  $udev_log = 'err',
-  $config_file_replace = true
+  $udev_log = $udev::params::udev_log,
+  $config_file_replace = $udev::params::config_file_replace,
 ) inherits udev::params {
   validate_re($udev_log, '^err$|^info$|^debug$')
   validate_bool($config_file_replace)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,9 @@
 # This class should be considered private.
 #
 class udev::params {
+  $config_file_replace = true
+
+  $udev_log     = 'err'
   $udevadm_path = '/sbin'
 
   case $::osfamily {


### PR DESCRIPTION
This just sets up udev to use udev::params for the defaults, no actual behavior changes
