### PR TITLE
Support for Puppet v4 parser type

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class udev::params {
           fail("Module ${module_name} might not be supported on Fedora release ${::operatingsystemmajrelease}")
         }
       } else {
-        case $::operatingsystemmajrelease {
+        case "${::operatingsystemmajrelease}" {
           '5': {
             $udev_package    = 'udev'
             $udevtrigger     = 'udevtrigger'


### PR DESCRIPTION
Fixes #20
- Explicit cast of `operatingsystemmajrelease` to String type
- Required for Puppet v4 support
