### PR TITLE
fixup of #19

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@
 class udev(
   $udev_log = $udev::params::udev_log,
   $config_file_replace = $udev::params::config_file_replace,
+  $rules = $udev::params::rules,
 ) inherits udev::params {
   validate_re($udev_log, '^err$|^info$|^debug$')
   validate_bool($config_file_replace)
@@ -48,4 +49,8 @@ class udev(
   Anchor['udev:begin'] ->
   class { 'udev::udevadm::logpriority': udev_log => $udev_log } ->
   Anchor['udev:end']
+
+  if $rules {
+    create_resources('udev::rule', $rules)
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class udev::params {
 
   $udev_log     = 'err'
   $udevadm_path = '/sbin'
+  $rules        = undef
 
   case $::osfamily {
     'debian': {

--- a/spec/classes/udev_spec.rb
+++ b/spec/classes/udev_spec.rb
@@ -80,6 +80,17 @@ describe 'udev', :type => :class do
       end
     end
 
+    describe 'rule parameter' do
+      let(:params) {{ 'rules' => { '99-foo.rules' => { 'content' => 'generic_rule' }}}}
+      it { should contain_file("/etc/udev/rules.d/99-foo.rules").with({
+          :owner   => 'root',
+          :group   => 'root',
+          :mode    => '0644',
+          :content => 'generic_rule',
+      })}
+    end
+
   end
+
 
 end


### PR DESCRIPTION
removes `Gemfile` changes related to `ruby < 2.0`.

closes \#19
resolves \#17