### PR TITLE
Parametrize udevtrigger in main class and add to trigger.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,11 +19,14 @@
 #
 # include udev
 #
-class udev(
+class udev (
+
   $udev_log = $udev::params::udev_log,
   $config_file_replace = $udev::params::config_file_replace,
   $rules = $udev::params::rules,
-) inherits udev::params {
+  $udevtrigger = $udev::params::udevtrigger,
+
+  ) inherits udev::params {
   validate_re($udev_log, '^err$|^info$|^debug$')
   validate_bool($config_file_replace)
 

--- a/manifests/udevadm/trigger.pp
+++ b/manifests/udevadm/trigger.pp
@@ -17,7 +17,7 @@ class udev::udevadm::trigger inherits udev::params {
   # cases.
   # http://unix.stackexchange.com/questions/39370/how-to-reload-udev-rules-without-reboot
 
-  exec { $udev::params::udevtrigger:
+  exec { $udev::udevtrigger:
     refreshonly => true,
     path        => $udev::params::udevadm_path,
   }


### PR DESCRIPTION
Hi! Thanks for the module at first!

I use Debian for my environment and the trigger with action change for udevadm not working.

With this Pull Request close #23 

I added the parametrized var `$udevtrigger` in the main class to be able to replace the content with hiera, in the class declaration, etc.

Thanks!